### PR TITLE
fix a README typo.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -20,7 +20,7 @@ Then you can use +Pledge.pledge+ as the interface to the pledge(2)
 system call.  You pass +Pledge.pledge+ a string containing tokens
 for the operations you would like to allow (called promises).
 For example, if you want to give the process the ability to read
-from the the file system, but not read from the file system or
+from the file system, but not read from the file system or
 allow network access:
 
   Pledge.pledge("rpath")


### PR DESCRIPTION
the README still seems to contradict itself though, see here:
```
if you want to give the process the ability to read
from the file system, but not read from the file system 
...
```
i'm not sure what you meant to say. 

